### PR TITLE
fixing Windows support due to spawn not finding 'grunt.cmd'

### DIFF
--- a/tasks/gruntgrunt.js
+++ b/tasks/gruntgrunt.js
@@ -4,7 +4,7 @@ var path = require('path');
 var chalk = require('chalk');
 var spawn = require('child_process').spawn;
 
-var isWindows = (process.platform === 'win32');
+var isWindows = process.platform === 'win32';
 
 module.exports = function (grunt) {
     grunt.registerMultiTask('grunt', 'Spawn Grunt tasks in other Gruntfiles easily from a Grunt task', function () {
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
         // var args = data.tasks.concat(['--gruntfile', data.gruntfile]);
         var cwd = path.dirname(data.gruntfile);
 
-        var child = spawn((isWindows) ? 'grunt.cmd' : 'grunt', data.tasks, {
+        var child = spawn(isWindows ? 'grunt.cmd' : 'grunt', data.tasks, {
             stdio: 'inherit',
             cwd: cwd,
             env: process.env


### PR DESCRIPTION
Here it is. 

`exec` wasn't useful as it does not support `stdio: 'inherit'`, so I just checked for windows and changed the command.
