### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ grunt.initConfig({
 });
 ```
 
+Also allows multiple task targets with options. **Note:** Options are applied to **all** tasks.
+
+```js
+grunt.initConfig({
+    grunt: {
+        buildsome: {
+            gruntfile: 'node_modules/some/Gruntfile.js',
+            tasks: ['jshint:client', 'build', '--verbose']
+        }
+    }
+});
+```
+
 Run it!
 
 ```shell


### PR DESCRIPTION
Added explanation on how to provide options to the tasks.

I mistakenly tried to run: tasks: 'default --verbose' or tasks: ['default --verbose'] which did not work. Options need to be provided as separate elements in the tasks array.