### PR TITLE
Update gruntgrunt.js due to Windows (CVE-2024-27980)

### DIFF
--- a/tasks/gruntgrunt.js
+++ b/tasks/gruntgrunt.js
@@ -29,7 +29,8 @@ module.exports = function (grunt) {
         var child = spawn(options.grunt, data.tasks, {
             stdio: 'inherit',
             cwd: cwd,
-            env: process.env
+            env: process.env,
+            shell: true
         });
 
         child.on('close', function (code) {


### PR DESCRIPTION
This is required for Windows due to https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2